### PR TITLE
Bump base image to quay.io/centos/centos:stream9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=centos:centos7
+ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
 FROM ${BASE_IMAGE}
 


### PR DESCRIPTION
We didn't do it for a while. New image contains tons of CVE fixes and is supported now.